### PR TITLE
fix: embed event poster as CID attachment for Android email compatibility

### DIFF
--- a/app/api/stripe/webhook/route.tsx
+++ b/app/api/stripe/webhook/route.tsx
@@ -9,6 +9,7 @@ import { Resend } from 'resend';
 import { ZVC_EMAIL_ADDRESS } from '@/app/contsants/constants';
 import TicketEmail from '@/emails/TicketEmail';
 import { Location } from '@/payload-types';
+import sharp from 'sharp';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -235,14 +236,37 @@ export async function POST(req: Request) {
               }
 
               try {
+                const imageUrl = `${process.env.VERCEL_BLOB_URL}${eventImage.filename}`;
+                let emailImageSrc = imageUrl;
+                let emailAttachments: Array<{ filename: string; content: Buffer; content_id: string }> = [];
+
+                try {
+                  const fetchUrl = eventImage.sizes?.emailPoster?.url ?? imageUrl;
+                  const imageResponse = await fetch(fetchUrl);
+                  if (imageResponse.ok) {
+                    let imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+                    if (!eventImage.sizes?.emailPoster?.url) {
+                      imageBuffer = await sharp(imageBuffer)
+                        .resize(200, 300, { fit: 'cover' })
+                        .jpeg({ quality: 75 })
+                        .toBuffer();
+                    }
+                    emailAttachments = [{ filename: 'event-poster.jpg', content: imageBuffer, content_id: 'event-poster' }];
+                    emailImageSrc = 'cid:event-poster';
+                  }
+                } catch (fetchErr) {
+                  await logtail.error(`API /stripe/webhook: Failed to fetch event image for embedding: ${fetchErr}`);
+                }
+
                 await resend.emails.send({
                   from: ZVC_EMAIL_ADDRESS,
                   subject: `Your ZVC Ticket: ${event.name}`,
                   to: email,
+                  attachments: emailAttachments,
                   react: (
                     <TicketEmail
                       eventName={event.name}
-                      eventImage={`${process.env.VERCEL_BLOB_URL}${eventImage.filename}`}
+                      eventImage={emailImageSrc}
                       eventDate={event.datetime}
                       eventLocation={(event.location as Location).name}
                       quantity={quantity}

--- a/app/api/test-email/route.tsx
+++ b/app/api/test-email/route.tsx
@@ -5,6 +5,7 @@ import { Resend } from 'resend';
 import { ZVC_EMAIL_ADDRESS } from '@/app/contsants/constants';
 import TicketEmail from '@/emails/TicketEmail';
 import { Location } from '@/payload-types';
+import sharp from 'sharp';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -47,21 +48,44 @@ export async function POST(req: Request) {
       );
     }
 
+    const imageUrl = `${process.env.VERCEL_BLOB_URL}${eventImage.filename}`;
+    let emailImageSrc = imageUrl;
+    let emailAttachments: Array<{ filename: string; content: Buffer; content_id: string }> = [];
+
+    try {
+      const fetchUrl = eventImage.sizes?.emailPoster?.url ?? imageUrl;
+      const imageResponse = await fetch(fetchUrl);
+      if (imageResponse.ok) {
+        let imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+        if (!eventImage.sizes?.emailPoster?.url) {
+          imageBuffer = await sharp(imageBuffer)
+            .resize(200, 300, { fit: 'cover' })
+            .jpeg({ quality: 75 })
+            .toBuffer();
+        }
+        emailAttachments = [{ filename: 'event-poster.jpg', content: imageBuffer, content_id: 'event-poster' }];
+        emailImageSrc = 'cid:event-poster';
+      }
+    } catch {
+      // fall back to external URL
+    }
+
     // Send test email with real event data
     const emailResult = await resend.emails.send({
       from: ZVC_EMAIL_ADDRESS,
       subject: `[TEST!!!] Your ZVC Ticket: ${event.name}`,
       to: testEmail,
+      attachments: emailAttachments,
       react: (
         <TicketEmail
           eventName={event.name}
-          eventImage={`${process.env.VERCEL_BLOB_URL}${eventImage.filename}`}
+          eventImage={emailImageSrc}
           eventDate={event.datetime}
           eventLocation={(event.location as Location).name}
-          quantity={1} // Test quantity
+          quantity={1}
           eventDescription={event.description}
           eventAddress={(event.location as Location).address}
-          totalAmount={25.0} // Test amount
+          totalAmount={25.0}
           purchaseDate={new Date().toISOString()}
         />
       ),

--- a/collections/Media.ts
+++ b/collections/Media.ts
@@ -12,5 +12,36 @@ export const Media: CollectionConfig = {
       required: true,
     },
   ],
-  upload: true,
+  upload: {
+    // Cap the stored original — no full-size file kept in Vercel Blob
+    // Not forcing JPEG here because logos/author photos may be PNG with transparency
+    resizeOptions: {
+      width: 800,
+      height: 1200,
+      fit: 'inside',
+      withoutEnlargement: true,
+    },
+    imageSizes: [
+      {
+        name: 'thumbnail',
+        width: 400,
+        height: 600,
+        position: 'center',
+        formatOptions: {
+          format: 'jpeg',
+          options: { quality: 80 },
+        },
+      },
+      {
+        name: 'emailPoster',
+        width: 200,
+        height: 300,
+        position: 'center',
+        formatOptions: {
+          format: 'jpeg',
+          options: { quality: 75 },
+        },
+      },
+    ],
+  },
 };

--- a/emails/TicketEmail.tsx
+++ b/emails/TicketEmail.tsx
@@ -22,7 +22,7 @@ interface Props {
   eventImage: string;
   eventDate: string;
   eventLocation: string;
-  eventDescription: SerializedEditorState;
+  eventDescription?: SerializedEditorState;
   eventAddress: string;
   quantity: number;
   customerName?: string;
@@ -269,10 +269,10 @@ export default function TicketEmail({
                                         align="center"
                                         style={{ padding: '20px 0' }}
                                       >
-                                        <img
+                                        <Img
                                           src={eventImage}
-                                          width="200"
-                                          height="300"
+                                          width={200}
+                                          height={300}
                                           alt="Event Poster"
                                           style={gmailEventImageStyle}
                                         />
@@ -810,6 +810,17 @@ export default function TicketEmail({
     </Html>
   );
 }
+
+export const previewProps: Props = {
+  eventName: 'Midnight Madness',
+  eventImage: 'https://s7qtxjaxzhtgrxvy.public.blob.vercel-storage.com/email%20header.png',
+  eventDate: '2025-09-13T20:00:00.000Z',
+  eventLocation: 'The Venue',
+  eventAddress: '418 Broadway Ste N, Albany, NY 12207',
+  quantity: 2,
+  totalAmount: 50.0,
+  purchaseDate: '2025-08-01T00:00:00.000Z',
+};
 
 // Gmail-compatible styles - removed border-radius and simplified fonts
 const main = {

--- a/lib/logtail.ts
+++ b/lib/logtail.ts
@@ -1,3 +1,8 @@
 import { Logtail } from '@logtail/node';
 
-export const logtail = new Logtail(process.env.BETTERSTACK_SOURCE_TOKEN!);
+const noop = () => Promise.resolve({} as any);
+const noopLogger = { info: noop, warn: noop, error: noop };
+
+export const logtail = process.env.BETTERSTACK_SOURCE_TOKEN
+  ? new Logtail(process.env.BETTERSTACK_SOURCE_TOKEN)
+  : noopLogger as unknown as Logtail;

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.956.0.tgz",
       "integrity": "sha512-O+Z7PSY9TjaqJcZSDMvVmXBuV/jmFRJIu7ga+9XgWv4+qfjhAX2N2s4kgsRnIdjIO4xgkN3O/BugTCyjIRrIDQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1147,6 +1148,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1489,6 +1491,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
       "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.0.0",
         "@dnd-kit/utilities": "^3.2.1",
@@ -2513,6 +2516,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "body-scroll-lock": "4.0.0-beta.0",
         "focus-trap": "7.5.4",
@@ -2534,6 +2538,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3614,7 +3619,6 @@
       "integrity": "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "^22.15.30",
         "@types/pg": "^8.8.0"
@@ -3629,7 +3633,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3903,6 +3906,7 @@
       "resolved": "https://registry.npmjs.org/@payloadcms/next/-/next-3.69.0.tgz",
       "integrity": "sha512-rkj/wvTDcbOkb8+v4jkZVdoJm2tvPUQL62CWoGnysy/ST+ZUwMr/70veLB7Ztr3uj6HKi6dU+31H+gG94UaMZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "6.0.8",
         "@dnd-kit/modifiers": "9.0.0",
@@ -7138,6 +7142,7 @@
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7390,6 +7395,7 @@
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7400,6 +7406,7 @@
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -8849,6 +8856,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
       "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -9306,6 +9314,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9316,6 +9325,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9346,8 +9356,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -9690,6 +9699,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10073,6 +10083,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10848,7 +10859,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -11039,7 +11049,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -11297,6 +11308,7 @@
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12420,7 +12432,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12623,7 +12634,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.115.tgz",
       "integrity": "sha512-noaW4yNp6hCjOgDnWWxW0vGXE3kZQI5Kqiwz+jIWXavI9J9WyfJ9zjsbQlQlgjIbHBrvlA/x3TSIXBUJj+0L6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -13799,7 +13809,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -13810,7 +13819,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -13893,6 +13901,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -14343,6 +14352,7 @@
       "resolved": "https://registry.npmjs.org/payload/-/payload-3.69.0.tgz",
       "integrity": "sha512-LiIybFUjAYYVYN2kSaieqDyQDglGeYuyPtP0xqkvIF5EOAGdNMMLSPmGHquV1kPeeUvzgv/CVoNIMEOuRF9wmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "^15.1.5",
         "@payloadcms/translations": "3.69.0",
@@ -14454,6 +14464,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -14744,6 +14755,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15087,6 +15099,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15433,6 +15446,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
       "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -15889,7 +15903,8 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -16766,7 +16781,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -16942,6 +16958,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17107,6 +17124,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17487,6 +17505,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },


### PR DESCRIPTION
## Summary

- Embeds the event poster image as a CID MIME attachment in ticket emails so Android email clients (Samsung Mail, etc.) that block external images display the poster correctly
- Uses pre-generated \`emailPoster\` size (200×300) from Payload when available, falling back to sharp resize for older uploads
- Adds \`imageSizes\` to the Media collection (thumbnail 400×600, emailPoster 200×300) so images are optimized at upload rather than on demand
- Caps stored originals to 800×1200 to reduce Vercel Blob storage costs
- Fixes \`<img>\` → \`<Img>\` in TicketEmail for consistent cross-client rendering
- Adds no-op logtail fallback so local dev starts without \`BETTERSTACK_SOURCE_TOKEN\`

## Test plan

- [ ] Send a test email via \`POST /api/test-email\` with a real event ID
- [ ] Open the email on an Android device and confirm the event poster loads
- [ ] Confirm the email renders correctly in Gmail web and Apple Mail
- [ ] Re-upload an event image in Payload admin and confirm thumbnail/emailPoster sizes are generated
- [ ] Confirm existing event images still work via the sharp fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)